### PR TITLE
Removing source strength heterogeneity and directional calling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 .Rhistory
+/man/
+.RData

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ Depends:
     testthat
 Imports:
     CircStats,
-    fastGHQuad,
     fields,
     mgcv,
     parallel,

--- a/R/convert.R
+++ b/R/convert.R
@@ -66,11 +66,13 @@ create.mask <- function(traps, buffer, ...){
 create.capt <- function(captures, traps = NULL, ind_model = NULL, n.sessions = NULL, n.traps = NULL, 
                         mrds.locs = NULL){
     
-    #captures must be provided as a matrix or data frame with at least 4 columns
-    #traps could be list, matrix or data frame
-    #traps, or (n.traps & n.sessions), one of them must be provided
-    stopifnot(is.data.frame(captures) | is.matrix(captures), ncol(captures) >= 4,
-              any(is.null(traps), is.list(traps), is.matrix(traps), is.data.frame(traps)),
+    # Make sure captures is DF or matrix
+    # Make sure required columns are included in captures (at least 4)
+    # Make sure traps is either list, matrix, data frame or NULL
+    # Make sure at least one of traps, or (n.traps & n.sessions) provided
+    stopifnot(is.data.frame(captures) | is.matrix(captures), 
+              ncol(captures) >= 4, 
+              any(is.null(traps), is.list(traps), is.matrix(traps), is.data.frame(traps)), 
               any(!is.null(traps), !is.null(n.traps) & !is.null(n.sessions)))
     
     if ((!missing(n.traps) | !missing(n.sessions)) & is.null(traps)){
@@ -90,9 +92,10 @@ create.capt <- function(captures, traps = NULL, ind_model = NULL, n.sessions = N
     #------------------------------------------------------------------------------------------------------
     #deal with n.sessions
     
-    #generate n.sessions based on "captures" data
+    #determine the maximum "captures" session number, and assume this is # sessions we are using 
     tem.n.sessions.capt = max(captures$session)
     
+    #if we have traps
     if(!is.null(traps)){
         #generate n.sessions based on "traps" data
         tem.n.sessions.trap = ifelse(is(traps, 'list'), length(traps), 1)

--- a/R/fit_acre.R
+++ b/R/fit_acre.R
@@ -263,16 +263,8 @@ fit_og = function(capt, traps, mask, detfn = NULL, sv = NULL, bounds = NULL, fix
 
 
   if(is.null(ss.opts)){
-    n_dir_quadpoints = 0
-    n_het_source_quadpoints = 0
-    het_source_nodes = 0
-    het_source_weights = 0
     cutoff = 0
   } else {
-    n_dir_quadpoints = ss.opts$n.dir.quadpoints
-    n_het_source_quadpoints = ss.opts$n.het.source.quadpoints
-    het_source_nodes = ss.opts$het.source.nodes
-    het_source_weights = ss.opts$het.source.weights
     cutoff = ss.opts$cutoff
   }
 
@@ -328,17 +320,10 @@ fit_og = function(capt, traps, mask, detfn = NULL, sv = NULL, bounds = NULL, fix
                sound_speed = sound.speed,
                cue_rates = mean.cue.rates,
 
-               #code of het_method:
-               #1:NULL, 2:GH, 3:rect
-               het_method = numeric_het_method(ss.opts$het.source.method),
-               n_dir_quadpoints = n_dir_quadpoints,
-               n_het_source_quadpoints = n_het_source_quadpoints,
-               het_source_nodes = het_source_nodes,
-               het_source_weights = het_source_weights,
+            
                cutoff = cutoff,
                #code of detfn_index:
-               #1:hn, 2:hhn, 3:hr, 4:th, 5:lth, 6:ss, 7:ss_dir, 8:ss_het
-               #temporarily ss_dir and ss_het are not supported
+               #1:hn, 2:hhn, 3:hr, 4:th, 5:lth, 6:ss
                detfn_index = numeric_detfn(detfn),
 
 
@@ -359,11 +344,7 @@ fit_og = function(capt, traps, mask, detfn = NULL, sv = NULL, bounds = NULL, fix
 
                is_animalID = as.numeric(animal.model),
                is_ss = as.numeric("ss" %in% bucket_info),
-               is_ss_origin = as.numeric(all("ss" %in% bucket_info,
-                                             !"ss.het" %in% bucket_info,
-                                             !"ss.dir" %in% bucket_info)),
-               is_ss_het = as.numeric("ss.het" %in% bucket_info),
-               is_ss_dir = as.numeric("ss.dir" %in% bucket_info),
+               is_ss_origin = as.numeric("ss" %in% bucket_info),
                is_bearing = as.numeric("bearing" %in% bucket_info),
                is_toa = as.numeric("toa" %in% bucket_info),
                is_dist = as.numeric("dist" %in% bucket_info),
@@ -421,9 +402,9 @@ fit_og = function(capt, traps, mask, detfn = NULL, sv = NULL, bounds = NULL, fix
   #in case there is any duplication, delete them
   name.fixed.par.4cpp = unique(name.fixed.par.4cpp)
 
-  if(!("ss.het" %in% bucket_info)){
-    name.fixed.par.4cpp = c(name.fixed.par.4cpp, "u")
-  }
+
+  name.fixed.par.4cpp = c(name.fixed.par.4cpp, "u")
+
 
   map = vector('list', length(name.fixed.par.4cpp))
   names(map) = name.fixed.par.4cpp
@@ -436,21 +417,12 @@ fit_og = function(capt, traps, mask, detfn = NULL, sv = NULL, bounds = NULL, fix
 
   #browser()
   if(!gr_skip){
-    if(!("ss.het" %in% bucket_info)){
-      obj <- TMB::MakeADFun(data = data, parameters = parameters, map = map, slient = (!tracing), DLL="acre")
-    } else {
-      obj <- TMB::MakeADFun(data = data, parameters = parameters, random = "u", map = map, slient = (!tracing), DLL="acre")
-    }
+    obj <- TMB::MakeADFun(data = data, parameters = parameters, map = map, slient = (!tracing), DLL="acre")
     obj$hessian <- TRUE
     opt = stats::nlminb(obj$par, obj$fn, obj$gr)
     o = TMB::sdreport(obj)
   } else {
-
-    if(!("ss.het" %in% bucket_info)){
-      obj <- TMB::MakeADFun(data = data, parameters = parameters, map = map, slient = (!tracing), DLL="acre", type = 'Fun')
-    } else {
-      obj <- TMB::MakeADFun(data = data, parameters = parameters, random = "u", map = map, slient = (!tracing), DLL="acre", type = 'Fun')
-    }
+    obj <- TMB::MakeADFun(data = data, parameters = parameters, map = map, slient = (!tracing), DLL="acre", type = 'Fun')
 
     par_name_fitted = param.og.4cpp[which(!param.og.4cpp %in% name.fixed.par.4cpp)]
     #the name of this ini_par_val is not right, do it later
@@ -746,9 +718,7 @@ read.acre = function(captures, traps, mask = NULL,
   arg.input <- vector('list', length(arg.names))
   names(arg.input) <- arg.names
   for(i in arg.names) {
-    if(!is.null(get(i))){
-      arg.input[[i]] = get(i)
-    }
+    arg.input[[i]] = get(i)
   }
 
 

--- a/R/functions_in_fit.R
+++ b/R/functions_in_fit.R
@@ -787,139 +787,26 @@ par.extend.fun = function(par.extend, data.full, data.mask, animal.model, dims, 
 ss.fun = function(ss.opts, data.full, data.ID_mask, animal.model, dims, bucket_info, sv, fix){
   cutoff <- ss.opts[["cutoff"]]
   ss.link <- ss.opts[["ss.link"]]
-  directional <- ss.opts[["directional"]]
-  het.source <- ss.opts[["het.source"]]
-  het.source.method <- ss.opts[["het.source.method"]]
-  n.dir.quadpoints <- ss.opts[["n.dir.quadpoints"]]
-  n.het.source.quadpoints <- ss.opts[["n.het.source.quadpoints"]]
-  
+  # directional <- ss.opts[["directional"]]
+  # het.source <- ss.opts[["het.source"]]
+  # het.source.method <- ss.opts[["het.source.method"]]
+  # n.dir.quadpoints <- ss.opts[["n.dir.quadpoints"]]
+  # n.het.source.quadpoints <- ss.opts[["n.het.source.quadpoints"]]
+  # 
   
   if("ss" %in% bucket_info){
     if(is.null(ss.opts)) stop("Argument 'ss.opts' is missing.")
     if(is.null(cutoff)) stop("The 'cutoff' component of 'ss.opts' must be specified.")
     ## Warning for unexpected component names.
-    if (!all(names(ss.opts) %in% c("cutoff", "het.source", "het.source.method",
-                                   "n.het.source.quadpoints", "directional",
-                                   "n.dir.quadpoints", "ss.link"))){
-      warning("Components of 'ss.opts' may only consist of \"cutoff\", \"het.source\",
-            \"het.source.method\", \"n.het.source.quadpoints\", \"directional\",
-            \"n.dir.quadpoints\", \"ss.link\";
+    if (!all(names(ss.opts) %in% c("cutoff", "ss.link"))){
+      warning("Components of 'ss.opts' may only consist of \"cutoff\", \"ss.link\";
             others are being ignored.")
     }
     
-    ## Setting default values for het.source and directional, ss.link.
-    
-    ## By default, directional calling model is only used if b2.ss appears in sv or fix.
-    if (is.null(directional)){
-      if (is.null(sv$b2.ss) & is.null(fix$b2.ss)){
-        directional <- FALSE
-      } else {
-        directional <- TRUE
-      }
-    }
-    
-    #make detailed and final judgment about ss.dir, and settle some basic settings
-    if (!directional){
-      if (!is.null(sv$b2.ss) | !is.null(fix$b2.ss)){
-        warning("Since the 'directional' component of 'ss.opts' is FALSE,
-        the values of parameter b2.ss in 'sv' and 'fix' are being ignored")
-      }
-      n.dir.quadpoints = NULL
-    } else {
-      if(!is.null(fix$b2.ss)){
-        if(fix$b2.ss != 0) {
-          bucket_info = c(bucket_info, "ss.dir")
-        } else {
-          warning("'fix$b2.ss' is zero,
-                  all corresponding parameters of 'directional' are ignored")
-          directional = FALSE
-          n.dir.quadpoints = NULL
-        }
-      } else {
-        bucket_info = c(bucket_info, "ss.dir")
-      }
-    }
-    
-    #after settling down all basic info of ss.dir, set default n.dir.quadpoints
-    if (directional){
-      if (is.null(n.dir.quadpoints)){
-        n.dir.quadpoints <- 8
-      }
-    } else {
-      n.dir.quadpoints <- 1
-    }
-    
-    ## By default, heterogeneity source strength model is only
-    ## used if sigma.b0.ss appears in sv or fix, or het.source.method is specified
-    if (is.null(het.source)){
-      if (all(is.null(sv$sigma.b0.ss),
-              is.null(fix$sigma.b0.ss),
-              is.null(het.source.method))){
-        het.source <- FALSE
-      } else {
-        het.source <- TRUE
-      }
-    }
-    
-    #make detailed and final judgment about ss.het, and settle some basic settings
-    if (het.source){
-      if (is.null(het.source.method)){
-        het.source.method <- "GH"
-      } else {
-        if(het.source.method %in% c("GH", "rect")) stop(paste0("Only 'GH' and 'rect' are ",
-                                                               "supported as het.source.method."))
-      }
-      if(!is.null(fix$sigma.b0.ss)){
-        if(fix$sigma.b0.ss != 0) {
-          bucket_info = c(bucket_info, "ss.het")
-        } else {
-          warning("'fix$sigma.b0.ss' is zero,
-                  all corresponding parameters of 'het.source' are ignored")
-          het.source = FALSE
-          het.source.method = NULL
-          n.het.source.quadpoints = NULL
-        }
-      } else {
-        bucket_info = c(bucket_info, "ss.het")
-      }
-    } else {
-      ## Fixing sigma.b0.ss to 0 if a heterogeneous source
-      ## strength model is not being used.
-      if (!is.null(sv$sigma.b0.ss) | !is.null(fix$sigma.b0.ss)){
-        warning("As the 'het.source' component of 'ss.opts' is FALSE,
-        the values of the parameter sigma.b0.ss in 'sv' and 'fix' are being ignored")
-      }
-      het.source.method = NULL
-      n.het.source.quadpoints = NULL
-    }
-    
-    #after settling down basic settings, assign default value to n.het...
-    if(het.source){
-      if(is.null(n.het.source.quadpoints)){
-        n.het.source.quadpoints <- 15
-      }
-    } else {
-      n.het.source.quadpoints <- 1
-    }
-    
-    
-    het.source.nodes <- 0
-    het.source.weights <- 0
-    if(het.source){
-      if(het.source.method == "GH"){
-        GHd <- fastGHQuad::gaussHermiteData(n.het.source.quadpoints)
-        het.source.nodes <- GHd$x
-        het.source.weights <- GHd$w
-      }
-    }
-    
-    
-    
-    
-    #simple check and simple argument adjustment
-    if(all(c("ss.dir", "ss.het") %in% bucket_info)){
-      stop("Fitting of models with both heterogeneity in source signal strength
-       and directional calling is not yet implemented.")
+    # Warning for heterogeneity and directional calling models
+    if(any(c("ss.dir", "ss.het") %in% bucket_info)){
+      stop("Fitting of models with either heterogeneity in source signal strength
+       or directional calling is not yet implemented.")
     }
     
     #set default for ss.link
@@ -929,21 +816,7 @@ ss.fun = function(ss.opts, data.full, data.ID_mask, animal.model, dims, bucket_i
       stop("Component 'ss.link' in 'ss.opts' must be \"identity\", \"log\", or \"spherical\".")
     }
     
-    ## Error thrown for model with heterogeneity in source strength and a log-link function.
-    if ("ss.het" %in% bucket_info){
-      if (ss.link != "identity"){
-        stop("Fitting of signal strength models with heterogeneity in source
-         signal strength is only implemented with an identity link function.")
-      }
-    }
-    
-    if('ss.dir' %in% bucket_info){
-      if(!('toa' %in% bucket_info)){
-        stop('"toa" is required for directional signal strength model.')
-      }
-    }
-    
-    
+
     
     data.ss = subset(data.full, !is.na(data.full$ID))
     data.no.det.session = subset(data.full, is.na(data.full$ID))
@@ -1005,14 +878,8 @@ ss.fun = function(ss.opts, data.full, data.ID_mask, animal.model, dims, bucket_i
     }
     
     #modified ss.opts, contains much condensed and regular information
-    ss.opts = list(het.source.method = het.source.method,
-                   n.dir.quadpoints = n.dir.quadpoints,
-                   n.het.source.quadpoints = n.het.source.quadpoints,
-                   het.source.nodes = het.source.nodes,
-                   het.source.weights = het.source.weights,
-                   ss.link = ss.link,
+    ss.opts = list(ss.link = ss.link,
                    cutoff = cutoff)
-    
     
   } else {
     if (!is.null(ss.opts)){
@@ -1035,9 +902,7 @@ ss.fun = function(ss.opts, data.full, data.ID_mask, animal.model, dims, bucket_i
                      "'sv' or 'fix' will be ignored"))
     }
   }
-  
-  
-  
+
   return(list(data.full = data.full, dims = dims, data.ID_mask = data.ID_mask,
               ss.opts = ss.opts, bucket_info = bucket_info))
 }
@@ -1114,13 +979,7 @@ param.detfn.fun = function(animal.model, sv, fix, bounds, name.extend.par, detfn
     #to be restored as original at very end of 'fit' function
     #ss_het only support ss.link == 'identity', but this has been checked in ss.fun
     if("ss" %in% bucket_info){
-      if("ss.het" %in% bucket_info){
-        detfn = 'ss_het'
-      } else if("ss.dir" %in% bucket_info){
-        detfn = 'ss_dir'
-      } else {
-        detfn = 'ss'
-      }
+      detfn = 'ss'
     } else {
       detfn = "hn"
     }
@@ -1129,14 +988,8 @@ param.detfn.fun = function(animal.model, sv, fix, bounds, name.extend.par, detfn
       if(detfn != 'ss'){
         warning('signal strenth is provided, therefore the specified "detfn" is ignored')
       }
-      
-      if("ss.het" %in% bucket_info){
-        detfn = 'ss_het'
-      } else if("ss.dir" %in% bucket_info){
-        detfn = 'ss_dir'
-      } else {
-        detfn = 'ss'
-      }
+      detfn = 'ss'
+
       
     } else {
       if(detfn == 'ss'){
@@ -1202,7 +1055,7 @@ param.detfn.fun = function(animal.model, sv, fix, bounds, name.extend.par, detfn
       design.matrices.mask[[i]] = matrix(0, ncol = 2, nrow = 2)
     }
     
-    #because intercept is in "data.full", so this design matrix always has someting
+    #because intercept is in "data.full", so this design matrix always has something
     design.matrices.full[[i]] = as.matrix(data.full[, which(clean.names.full == i), drop = FALSE])
     
     if(i %in% param.og){

--- a/R/functions_in_fit.R
+++ b/R/functions_in_fit.R
@@ -165,9 +165,7 @@ mask.fun = function(mask, dims, animal.model, data.traps, data.full, bucket_info
     
     mask[[i]] <- as.matrix(mask[[i]])
     dists[[i]] <- distances(as.matrix(traps), mask[[i]])
-    #based on the main procedure, at this stage, we don't know whether it is "ss.dir",
-    #since it should be determined at later stage when deal with "ss"
-    #so we generate bearings anyway.
+
     thetas[[i]] = bearings(as.matrix(traps), mask[[i]])
     
     data.dists.thetas[[i]] = data.frame(session = rep(i, n.masks[i] * n.traps[i]),
@@ -787,13 +785,7 @@ par.extend.fun = function(par.extend, data.full, data.mask, animal.model, dims, 
 ss.fun = function(ss.opts, data.full, data.ID_mask, animal.model, dims, bucket_info, sv, fix){
   cutoff <- ss.opts[["cutoff"]]
   ss.link <- ss.opts[["ss.link"]]
-  # directional <- ss.opts[["directional"]]
-  # het.source <- ss.opts[["het.source"]]
-  # het.source.method <- ss.opts[["het.source.method"]]
-  # n.dir.quadpoints <- ss.opts[["n.dir.quadpoints"]]
-  # n.het.source.quadpoints <- ss.opts[["n.het.source.quadpoints"]]
-  # 
-  
+
   if("ss" %in% bucket_info){
     if(is.null(ss.opts)) stop("Argument 'ss.opts' is missing.")
     if(is.null(cutoff)) stop("The 'cutoff' component of 'ss.opts' must be specified.")
@@ -977,7 +969,6 @@ param.detfn.fun = function(animal.model, sv, fix, bounds, name.extend.par, detfn
   if(is.null(detfn)){
     #the detfn in 'ss' is a little different from original, may be needed
     #to be restored as original at very end of 'fit' function
-    #ss_het only support ss.link == 'identity', but this has been checked in ss.fun
     if("ss" %in% bucket_info){
       detfn = 'ss'
     } else {

--- a/src/acreTMB.h
+++ b/src/acreTMB.h
@@ -463,6 +463,7 @@ Type essx_ss_spherical(const Type &dx, const vector<Type> &param){
 }
 
 //ss_dir
+//currently not in use
 template<class Type>
 Type essx_ss_dir_identical(const Type &dx, const vector<Type> &param){
   Type b0_ss = param(0);
@@ -499,6 +500,7 @@ Type essx_ss_dir_spherical(const Type &dx, const vector<Type> &param){
 }
 
 //ss_het
+//currently not in use
 template<class Type>
 Type essx_ss_het(const Type &dx, const vector<Type> &param){
   Type b0_ss = param(0);
@@ -542,11 +544,6 @@ Type acreTMB(objective_function<Type>* obj)
   DATA_SCALAR(sound_speed);
   DATA_SCALAR(cue_rates);
   
-  DATA_INTEGER(het_method);
-  DATA_INTEGER(n_dir_quadpoints);
-  DATA_INTEGER(n_het_source_quadpoints);
-  DATA_VECTOR(het_source_nodes);
-  DATA_VECTOR(het_source_weights);
   DATA_SCALAR(cutoff);
   
   
@@ -560,8 +557,6 @@ Type acreTMB(objective_function<Type>* obj)
   DATA_INTEGER(is_animalID);
   DATA_INTEGER(is_ss);
   DATA_INTEGER(is_ss_origin);
-  DATA_INTEGER(is_ss_het);
-  DATA_INTEGER(is_ss_dir);
   DATA_INTEGER(is_bearing);
   DATA_INTEGER(is_toa);
   DATA_INTEGER(is_dist);
@@ -674,18 +669,6 @@ Type acreTMB(objective_function<Type>* obj)
       detfn = essx_ss_spherical;
     }
     n_detfn_param = 2;
-  } else if(detfn_index == 7){
-    if(ss_link == 1){
-      detfn = essx_ss_dir_identical;
-    } else if(ss_link == 2){
-      detfn = essx_ss_dir_log;
-    } else if(ss_link == 4){
-      detfn = essx_ss_dir_spherical;
-    }
-    n_detfn_param = 4;
-  } else if(detfn_index == 8){
-    detfn = essx_ss_het;
-    n_detfn_param = 3;
   }
   //define the parameter vector which will be used later
   vector<Type> detfn_param(n_detfn_param);
@@ -1380,27 +1363,7 @@ Type acreTMB(objective_function<Type>* obj)
           detfn_param(0) = b0_ss_tem;
           detfn_param(1) = b1_ss_tem;
           
-        } else if(detfn_index == 7){
-          *p_b0_ss_tem = *p_b0_ss_full + *p_b0_ss_mask;
-          trans(p_b0_ss_tem, par_link(8));
-          *p_b1_ss_tem = *p_b1_ss_full + *p_b1_ss_mask;
-          trans(p_b1_ss_tem, par_link(9));
-          *p_b2_ss_tem = *p_b2_ss_full + *p_b2_ss_mask;
-          trans(p_b2_ss_tem, par_link(10));
-          
-          p_b0_ss_full++;
-          p_b1_ss_full++;
-          p_b2_ss_full++;
-          
-          
-          detfn_param(0) = b0_ss_tem;
-          detfn_param(1) = b1_ss_tem;
-          detfn_param(2) = b2_ss_tem;
-          detfn_param(3) = *p_theta;
-          
-          p_theta++;
         } 
-        //het is detfn_index == 8, not sure how to do it yet
         
         
         
@@ -1497,7 +1460,7 @@ Type acreTMB(objective_function<Type>* obj)
                 if(is_ss == 0){
                   fw(m - 1) *= pow(p_k(m - 1, t - 1), capt_bin_uid(index_data_uid)) * 
                     pow((1 - p_k(m - 1, t - 1)), (1 - capt_bin_uid(index_data_uid)));
-                } else if(is_ss_het == 0){
+                } else {
                   //pow(p_k(), capt_bin()) term could be cancelled out with fy_ss
                   fw(m - 1) *= pow((1 - p_k(m - 1, t - 1)), (1 -capt_bin_uid(index_data_uid)));
                 }
@@ -1520,7 +1483,7 @@ Type acreTMB(objective_function<Type>* obj)
                   if(is_ss == 0){
                     fw(m - 1) *= pow(p_k(m - 1, t - 1), capt_bin_uid(index_data_uid)) * 
                       pow((1 - p_k(m - 1, t - 1)), (1 - capt_bin_uid(index_data_uid)));
-                  } else if(is_ss_het == 0){
+                  } else {
                     //pow(p_k(), capt_bin()) term could be cancelled out with fy_ss
                     fw(m - 1) *= pow((1 - p_k(m - 1, t - 1)), (1 - capt_bin_uid(index_data_uid)));
                   }
@@ -1800,7 +1763,7 @@ Type acreTMB(objective_function<Type>* obj)
 				  if(is_ss == 0){
 					l_w *= pow(p_k(m - 1, t - 1), capt_bin[index_data_full]) *
 					  pow((1 - p_k(m - 1, t - 1)), (1 - capt_bin[index_data_full]));
-				  } else if(is_ss_het == 0){
+				  } else {
 					//pow(p_k(), capt_bin()) term could be cancelled out with fy_ss
 					l_w *= pow((1 - p_k(m - 1, t - 1)), (1 - capt_bin[index_data_full]));
 				  }
@@ -1941,7 +1904,7 @@ Type acreTMB(objective_function<Type>* obj)
 					if(is_ss == 0){
 					  l_w *= pow(p_k(m - 1, t - 1), capt_bin[index_data_full]) *
 						pow((1 - p_k(m - 1, t - 1)), (1 - capt_bin[index_data_full]));
-					} else if(is_ss_het == 0){
+					} else {
 					  //pow(p_k(), capt_bin()) term could be cancelled out with fy_ss
 					  l_w *= pow((1 - p_k(m - 1, t - 1)), (1 - capt_bin[index_data_full]));
 					}


### PR DESCRIPTION
I've gone through and removed all the code linked to ss_het and ss_dir methods.

I've done a pretty thorough job, but I wouldn't be suprised if there was some bits of documentation here and there still leftover, which we can just remove when we see.

Passes all the tests (except for those which are due to an issue being solved in [this](https://github.com/b-steve/acre/tree/issue-7-r-cmd-check-output) branch.

Finally, have removed fastGHQuad from Imports.